### PR TITLE
[feat/env] local에서 backend 코드 저장 시 자동 reload

### DIFF
--- a/backend/app/api/routes/util_router.py
+++ b/backend/app/api/routes/util_router.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+router = APIRouter(
+    prefix = "/api/util"
+)
+
+
+@router.get("/health-check/")
+async def health_check() -> bool:
+    return True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,4 @@
-from app.api.routes import user_router
-from app.api.routes import chat_router
+from app.api.routes import user_router, chat_router, util_router
 
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
@@ -24,7 +23,7 @@ app.add_middleware(
 
 app.include_router(user_router.router)
 app.include_router(chat_router.router)
-
+app.include_router(util_router.router)
 # @app.get("/")
 # def index():
 #   return FileResponse("frontend/dist/index.html")

--- a/backend/scripts/start-reload.sh
+++ b/backend/scripts/start-reload.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-80}
+LOG_LEVEL=${LOG_LEVEL:-info}
+
+# If there's a prestart.sh script in the /app directory, run it before starting
+PRE_START_PATH=/app/prestart.sh
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Uvicorn with live reload
+exec uvicorn --reload --host $HOST --port $PORT --log-level $LOG_LEVEL "$APP_MODULE"

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,0 +1,8 @@
+services:
+  backend:
+    restart: "no"
+    build:
+      args:
+        INSTALL_DEV: ${INSTALL_DEV-true}
+    # command: sleep infinity  # Infinite loop to keep container alive doing nothing
+    command: bash /app/scripts/start-reload.sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,6 +55,11 @@ services:
           - driver: nvidia
             device_ids: ['0']
             capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/api/util/health-check/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 
   frontend:


### PR DESCRIPTION
- 현재 local gpu 서버에 docker-compose 버전을 update 할 수 없어 start-reload.sh을 이용하여 기능 구현

- health-check 기능 구현(일정 시간마다 true 값을 return 하는 get method routing 구현

```
@router.get("/health-check/")
async def health_check() -> bool:
    return True
```