### PR TITLE
[fix] docker-compose.override.yaml 파일 ip 및 port 번호 명시적으로 default 설정

### DIFF
--- a/backend/scripts/start-reload.sh
+++ b/backend/scripts/start-reload.sh
@@ -10,8 +10,7 @@ MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
 VARIABLE_NAME=${VARIABLE_NAME:-app}
 export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
 
-HOST=${HOST:-0.0.0.0}
-PORT=${PORT:-80}
+
 LOG_LEVEL=${LOG_LEVEL:-info}
 
 # If there's a prestart.sh script in the /app directory, run it before starting
@@ -24,5 +23,9 @@ else
     echo "There is no script $PRE_START_PATH"
 fi
 
+alembic upgrade head
+
+ollama serve &
+
 # Start Uvicorn with live reload
-exec uvicorn --reload --host $HOST --port $PORT --log-level $LOG_LEVEL "$APP_MODULE"
+exec uvicorn --reload --host 0.0.0.0 --port 8000 --log-level $LOG_LEVEL "$APP_MODULE"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,7 +56,7 @@ services:
             device_ids: ['0']
             capabilities: [gpu]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/api/util/health-check/"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/util/health-check/"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
- backend

   ip: 0.0.0.0

   port: 8000

- ollama 및 alembic 설정

docker-compose.override.yaml이 docker-compose의 command 인자를 override 하기 때문에 ollama serve와 alembic upgrade head가 설정이 되지 않았음