### PR TITLE
[refactor] update_chat -> rename_chat_session

### DIFF
--- a/backend/app/api/routes/chat_router.py
+++ b/backend/app/api/routes/chat_router.py
@@ -93,12 +93,16 @@ def create_chat(
 
 
 @router.put("/rename/{chat_session_id}")
-def update_chat(
+def rename_chat_session(
     chat_session_id: int,
     chat_session_update_request: chat_schema.ChatSessionUpdateRequest,
     db: SessionDep,
 ) -> None:
-    chat_crud.update_chat_session(db, chat_session_id, chat_session_update_request)
+    chat_session = chat_crud.get_chat_session(db, chat_session_id)
+    if not chat_session:
+        raise HTTPException(status_code=404, detail="chat session not found")
+
+    chat_crud.update_chat_session(db, chat_session, chat_session_update_request)
 
 
 @router.delete("/delete/{chat_session_id}")

--- a/backend/app/crud/chat_crud.py
+++ b/backend/app/crud/chat_crud.py
@@ -66,11 +66,12 @@ def create_chat_session(
 
 def update_chat_session(
     db: Session,
-    chat_session_id: int,
+    chat_session: ChatSession,
     chat_session_update_request: chat_schema.ChatSessionUpdateRequest,
 ) -> None:
-    chat_session = get_chat_session(db, chat_session_id)
-    chat_session.title = chat_session_update_request.renamed_title
+    update_dict = chat_session_update_request.model_dump(exclude_unset=True)
+    for key, value in update_dict.items():
+        setattr(chat_session, key, value)
     db.add(chat_session)
     db.commit()
 

--- a/backend/app/schemas/chat_schema.py
+++ b/backend/app/schemas/chat_schema.py
@@ -53,7 +53,7 @@ class ChatSessionCreateRequest(BaseModel):
 
 
 class ChatSessionUpdateRequest(BaseModel):
-    renamed_title: str
+    title: str
 
 
 class ConversationCreate(BaseModel):

--- a/frontend/src/routes/Home.svelte
+++ b/frontend/src/routes/Home.svelte
@@ -258,8 +258,8 @@
     if (newChatTitle.trim() === '' || newChatTitle === chatTitle.title) {
       return
     }
-    let url = `/api/v1/chat/rename/${chatTitle.id}`;  // TODO: url 및 inDTO 변경
-    let params = { renamed_title: newChatTitle };
+    let url = `/api/v1/chat/rename/${chatTitle.id}`;
+    let params = { title: newChatTitle };
 
     fastapi('put', url, params,
       (json) => {


### PR DESCRIPTION
### 1. **`update_chat` Routing 함수 리팩토링**:

- **`chat_session_id`가 DB에서 조회되지 않을 경우**: 해당 채팅 세션이 존재하지 않으면 HTTP 404 Not Found 에러를 반환하도록 처리.
- **함수명 변경**:
    - `update_chat` → `rename_chat_session`
    - **이유**: `update_chat`는 chat_session의 `title`만 변경하므로 `rename_chat_session`이라는 명칭이 더 적합

### 2. **`update_chat_session` 함수 리팩토링**:

- 기존에는 `chat_session_update_request`의 각 필드를 수동으로 할당하여 세션을 업데이트했지만, **model_dump 메소드**를 사용해 요청 객체를 딕셔너리로 변환하고 이를 통해 동적으로 세션 속성을 업데이트하는 방식으로 변경
- **`model_dump(exclude_unset=True)`**: 요청된 값만 필터링하여 변환하고, **`setattr`*을 사용해 `chat_session` 모델의 속성을 동적으로 업데이트
- 이 변경을 통해 코드의 **유연성**이 향상되고, 새로운 필드가 추가되거나 변경되더라도 기존 코드를 수정할 필요가 줄어듦

### 3. **Dependency 변경**:

- **스키마 수정**: `update` 스키마에서 `renamed_title`을 `chat session` 모델의 `title`과 동일한 필드 이름으로 변경.
- **Frontend DTO 변경**: 프론트엔드에서 보내는 데이터 구조를 `renamed_title`에서 `title`로 수정.

### 4. **장점**:

- **버그 대처**: 만족하는 chat session id가 없을 때 404 error 반환하여 디버깅에 용이
- **유지보수성 향상**: 새 필드가 추가되거나 기존 필드가 변경될 때 코드 변경이 최소화되어 관리가 쉬워짐
- **유연성 강화**: 필드가 추가되거나 제거되어도 자동으로 업데이트가 가능하며, 하드코딩된 필드에 의존하지 않음